### PR TITLE
fix: ensure www-data ownership

### DIFF
--- a/docker-sourcebans-entrypoint.sh
+++ b/docker-sourcebans-entrypoint.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 if [ "true" == $INSTALL ]; then
     rm -rf /var/www/html/themes/default /var/www/html/updater /var/www/html/install /var/www/html/pages /var/www/html/includes
     cp -R /usr/src/sourcebans/* /var/www/html/
+    chown -R www-data:www-data /var/www/html/
 fi
 
 # If $INSTALL is set to false or not set, remove the install and updater directories


### PR DESCRIPTION
After `cp -R /usr/src/sourcebans/* /var/www/html`, the ownership of multiple `/var/www/html` children remains as `root` and the SourceBans++ installer complains about lacking write privileges. Granting `www-data:www-data` ownership seems like a reasonable approach.

For rootful Docker users.